### PR TITLE
Add a connect and a diconnect function to enable usage without contex…

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 120
+max-line-length = 130

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It has these advantages:
 
 ## Usage
 
-Each "connection" to a projector is managed through a `PJLink` context manager.  Once this is connected, you access the different functions through a high level API (e.g. `conn.power.turn_off()`, `conn.lamps.hours()`, `conn.errors.query()`, etc).
+Each "connection" to a projector can be managed through a `PJLink` context manager. Once this is connected, you access the different functions through a high level API (e.g. `conn.power.turn_off()`, `conn.lamps.hours()`, `conn.errors.query()`, etc).
 
 For example, create a `PJLink` connection to the projector and issue commands:
 
@@ -58,6 +58,16 @@ async with PJLink(address="192.168.1.120", password="secretpassword") as link:
     await asyncio.sleep(5)
     await link.power.turn_off()
 ```
+
+Alternatively, you can create a `PJLink` connection and manage it manually. But remember to call `disconnect` when you're done!
+
+```python
+link = PJLink(address="192.168.1.120", password="secretpassword")
+await link.connect()
+# ... use the link ...
+await link.disconnect()
+```
+
 
 ## Development
 

--- a/aiopjlink/projector.py
+++ b/aiopjlink/projector.py
@@ -109,6 +109,7 @@ class PJLink:
     C2 = PJClass.TWO
 
     def __init__(self, address, port=4352, password=None, timeout=4, encoding='utf-8'):
+        self._initialized = False
         self._tx_lock = asyncio.Lock()
         self._reader = None
         self._writer = None
@@ -138,6 +139,10 @@ class PJLink:
 
     async def connect(self):
         """ Open a connection to the projector and authenticate. """
+
+        # Clean up any existing connection before trying to connect again.
+        await self._close_socket()
+
         try:
             self._reader, self._writer = await asyncio.wait_for(
                 asyncio.open_connection(self._address, self._port),
@@ -168,6 +173,7 @@ class PJLink:
 
             # Connection requires no auth: `PJLINK 0\r`.
             if auth_enabled == '0':
+                self._initialized = True
                 return self
 
             # Connection requires auth: `PJLINK 1 <token>`.
@@ -195,15 +201,13 @@ class PJLink:
             if response.upper() == 'PJLINK ERRA\r':
                 raise PJLinkPassword('authentication failed')
             self._parse_response(response, expect_command='POWR', expect_pjclass=PJClass.ONE)
+            self._initialized = True
             return self
 
         except Exception:
             # If the connection fails during the handshake, __aexit__ will not be called.
             # Clean up immediately to avoid leaking the socket and throwing resource warnings.
-            if self._writer is not None:
-                self._writer.close()
-            self._writer = None
-            self._reader = None
+            await self._close_socket()
 
             # Re-raise the issue so it is not lost.
             raise
@@ -213,6 +217,11 @@ class PJLink:
 
     async def disconnect(self):
         """ Close an open connection to the projector. """
+        await self._close_socket()
+        self._initialized = False
+
+    async def _close_socket(self):
+        """ Internal helper to safely close the streams without changing initialization state. """
         try:
             if self._writer is not None:
                 self._writer.close()
@@ -254,31 +263,37 @@ class PJLink:
         """
         # Only one command/reconnection at a time.
         async with self._tx_lock:
+            try:
+                # Guard against lazy/unintended connections
+                if not self._initialized:
+                    raise PJLinkNoConnection(
+                        "You must explicitly connect() or use the async context manager before transmitting."
+                        )
 
-            # Guard against lazy/unintended connections
-            if self._writer is None:
-                raise PJLinkNoConnection("You must explicitly connect() or use the async context manager before transmitting.")
+                # Try to reconnect if the socket dropped.
+                if not self.is_connected:
+                    await self.connect()
 
-            # Try to reconnect if the socket dropped.
-            if not self.is_connected:
-                await self.connect()
+                # Generate the command string.
+                cstring = self._format_command(command, param, pjclass)
 
-            # Generate the command string.
-            cstring = self._format_command(command, param, pjclass)
+                # Send the command string.
+                cbytes = bytearray(cstring, self._encoding)
+                if PRINT_DEBUG_COMMS:
+                    print("🚢", cbytes)
+                self._writer.write(cbytes)
+                await self._writer.drain()
 
-            # Send the command string.
-            cbytes = bytearray(cstring, self._encoding)
-            if PRINT_DEBUG_COMMS:
-                print("🚢", cbytes)
-            self._writer.write(cbytes)
-            await self._writer.drain()
+                # Get the response.
+                response = await self._read_next()
 
-            # Get the response.
-            response = await self._read_next()
+                # Parse the response.
+                _, param = PJLink._parse_response(response, expect_command=command, expect_pjclass=pjclass)
+                return param
 
-            # Parse the response.
-            _, param = PJLink._parse_response(response, expect_command=command, expect_pjclass=pjclass)
-            return param
+            except Exception:
+                await self._close_socket()
+                raise
 
     @property
     def is_connected(self):

--- a/aiopjlink/projector.py
+++ b/aiopjlink/projector.py
@@ -234,6 +234,9 @@ class PJLink:
         Returns:
             str: The response to the issued command.
         """
+        if not self.is_connected:
+            await self.connect()
+
         # Generate the command string.
         cstring = self._format_command(command, param, pjclass)
 
@@ -250,6 +253,10 @@ class PJLink:
         # Parse the response.
         _, param = PJLink._parse_response(response, expect_command=command, expect_pjclass=pjclass)
         return param
+
+    @property
+    def is_connected(self):
+        return self._writer is not None and not self._writer.is_closing()
 
     @staticmethod
     def _format_command(command, param, pjclass: PJClass):

--- a/aiopjlink/projector.py
+++ b/aiopjlink/projector.py
@@ -133,6 +133,9 @@ class PJLink:
         raise NotImplementedError('class 2 method not supported')
 
     async def __aenter__(self):
+        return await self.connect()
+
+    async def connect(self):
         """ Open a connection to the projector and authenticate. """
         try:
             self._reader, self._writer = await asyncio.wait_for(
@@ -193,6 +196,9 @@ class PJLink:
         return self
 
     async def __aexit__(self, exc_type, exc_value, exc_tb):
+        await self.disconnect()
+
+    async def disconnect(self):
         """ Close an open connection to the projector. """
         try:
             self._writer.close()

--- a/aiopjlink/projector.py
+++ b/aiopjlink/projector.py
@@ -155,7 +155,7 @@ class PJLink:
         # data = await self._raw_read(n_bytes=9)
         try:
             data = await self._read_next()
-        except asyncio.exceptions.TimeoutError:
+        except PJLinkNoConnection:
             raise PJLinkProtocolError('projector did not send a welcome message')
         if len(data) < 9:
             raise PJLinkProtocolError('unexpected opening header message from projector - too short')
@@ -213,6 +213,8 @@ class PJLink:
             raw = await asyncio.wait_for(self._reader.readuntil(b'\r'), self._timeout)
         except asyncio.IncompleteReadError as err:
             raise PJLinkConnectionClosed('projector closed the connection') from err
+        except TimeoutError as err:
+            raise PJLinkNoConnection('projector did not respond in time') from err
         return raw.decode(self._encoding)
 
     async def transmit(self, command, param, pjclass: PJClass):

--- a/aiopjlink/projector.py
+++ b/aiopjlink/projector.py
@@ -109,6 +109,7 @@ class PJLink:
     C2 = PJClass.TWO
 
     def __init__(self, address, port=4352, password=None, timeout=4, encoding='utf-8'):
+        self._tx_lock = asyncio.Lock()
         self._reader = None
         self._writer = None
         self._address = address
@@ -147,53 +148,65 @@ class PJLink:
         except OSError as err:
             raise PJLinkNoConnection(f"os timeout - {str(err)}")
 
-        # An authentication procedure is executed once after each establishment of TCP/IP connection.
-        # The authentication procedure involves a password verification process.
-        # See https://pjlink.jbmia.or.jp/english/data_cl2/PJLink_5-1.pdf SECTION 5
-
-        # Projector sends first message to identify itself as PJLINK.
-        # data = await self._raw_read(n_bytes=9)
         try:
-            data = await self._read_next()
-        except PJLinkNoConnection:
-            raise PJLinkProtocolError('projector did not send a welcome message')
-        if len(data) < 9:
-            raise PJLinkProtocolError('unexpected opening header message from projector - too short')
+            # An authentication procedure is executed once after each establishment of TCP/IP connection.
+            # The authentication procedure involves a password verification process.
+            # See https://pjlink.jbmia.or.jp/english/data_cl2/PJLink_5-1.pdf SECTION 5
 
-        auth_header, auth_enabled, auth_close = data[:7], data[7], data[8]
-        if auth_header.upper() != 'PJLINK ':
-            raise PJLinkProtocolError('unexpected opening header message from projector - not PJLink')
+            # Projector sends first message to identify itself as PJLINK.
+            try:
+                data = await self._read_next()
+            except PJLinkNoConnection:
+                raise PJLinkProtocolError('projector did not send a welcome message')
 
-        # Connection requires no auth: `PJLINK 0\r`.
-        if auth_enabled == '0':
+            if len(data) < 9:
+                raise PJLinkProtocolError('unexpected opening header message from projector - too short')
+
+            auth_header, auth_enabled, auth_close = data[:7], data[7], data[8]
+            if auth_header.upper() != 'PJLINK ':
+                raise PJLinkProtocolError('unexpected opening header message from projector - not PJLink')
+
+            # Connection requires no auth: `PJLINK 0\r`.
+            if auth_enabled == '0':
+                return self
+
+            # Connection requires auth: `PJLINK 1 <token>`.
+            if auth_enabled != '1' and auth_close != ' ':
+                raise PJLinkProtocolError('unexpected opening security message from projector - unrecognised auth method')
+
+            # Check we have a password specified.
+            if self._password is None:
+                raise PJLinkPassword('password required')
+
+            # Read the random number used to salt the password (excluding the terminating `\r`).
+            token = data[9:-1]
+            passcode = (token + self._password).encode('utf-8')
+            passcode_md5 = hashlib.md5(passcode).hexdigest()
+
+            # The PJLINK authentication procedure requires the password and the first command to be
+            # transmitted together.  We send a power status request for simplicity.
+            self._writer.write(bytearray(passcode_md5, encoding=self._encoding))
+            self._writer.write(b'%1POWR ?\r')
+            await self._writer.drain()
+
+            # Read the first few bytes of the response - check for failed auth.
+            # ERRA represents ERR or authorization.
+            response = await self._read_next()
+            if response.upper() == 'PJLINK ERRA\r':
+                raise PJLinkPassword('authentication failed')
+            self._parse_response(response, expect_command='POWR', expect_pjclass=PJClass.ONE)
             return self
 
-        # Connection requires auth: `PJLINK 1 <token>`.
-        if auth_enabled != '1' and auth_close != ' ':
-            raise PJLinkProtocolError('unexpected opening security message from projector - unrecognised auth method')
+        except Exception:
+            # If the connection fails during the handshake, __aexit__ will not be called.
+            # Clean up immediately to avoid leaking the socket and throwing resource warnings.
+            if self._writer is not None:
+                self._writer.close()
+            self._writer = None
+            self._reader = None
 
-        # Check we have a password specified.
-        if self._password is None:
-            raise PJLinkPassword('password required')
-
-        # Read the random number used to salt the password (excluding the terminating `\r`).
-        token = data[9:-1]
-        passcode = (token + self._password).encode('utf-8')
-        passcode_md5 = hashlib.md5(passcode).hexdigest()
-
-        # The PJLINK authentication procedure requires the password and the first command to be
-        # transmitted together.  We send a power status request for simplicity.
-        self._writer.write(bytearray(passcode_md5, encoding=self._encoding))
-        self._writer.write(b'%1POWR ?\r')
-        await self._writer.drain()
-
-        # Read the first few bytes of the response - check for failed auth.
-        # ERRA represents ERR or authorization.
-        response = await self._read_next()
-        if response.upper() == 'PJLINK ERRA\r':
-            raise PJLinkPassword('authentication failed')
-        self._parse_response(response, expect_command='POWR', expect_pjclass=PJClass.ONE)
-        return self
+            # Re-raise the issue so it is not lost.
+            raise
 
     async def __aexit__(self, exc_type, exc_value, exc_tb):
         await self.disconnect()
@@ -201,7 +214,12 @@ class PJLink:
     async def disconnect(self):
         """ Close an open connection to the projector. """
         try:
-            self._writer.close()
+            if self._writer is not None:
+                self._writer.close()
+                try:
+                    await self._writer.wait_closed()
+                except Exception:
+                    pass
         finally:
             self._reader = None
             self._writer = None
@@ -234,30 +252,40 @@ class PJLink:
         Returns:
             str: The response to the issued command.
         """
-        if not self.is_connected:
-            await self.connect()
+        # Only one comman/reconnection at a time.
+        async with self._tx_lock:
 
-        # Generate the command string.
-        cstring = self._format_command(command, param, pjclass)
+            # Guard against lazy/unintended connections
+            if self._writer is None:
+                raise PJLinkNoConnection("You must explicitly connect() or use the async context manager before transmitting.")
 
-        # Send the command string.
-        cbytes = bytearray(cstring, self._encoding)
-        if PRINT_DEBUG_COMMS:
-            print("🚢", cbytes)
-        self._writer.write(cbytes)
-        await self._writer.drain()
+            # Try to reconnect if the socket dropped.
+            if not self.is_connected:
+                await self.connect()
 
-        # Get the response.
-        response = await self._read_next()
+            # Generate the command string.
+            cstring = self._format_command(command, param, pjclass)
 
-        # Parse the response.
-        _, param = PJLink._parse_response(response, expect_command=command, expect_pjclass=pjclass)
-        return param
+            # Send the command string.
+            cbytes = bytearray(cstring, self._encoding)
+            if PRINT_DEBUG_COMMS:
+                print("🚢", cbytes)
+            self._writer.write(cbytes)
+            await self._writer.drain()
+
+            # Get the response.
+            response = await self._read_next()
+
+            # Parse the response.
+            _, param = PJLink._parse_response(response, expect_command=command, expect_pjclass=pjclass)
+            return param
 
     @property
     def is_connected(self):
         """ True if the connection is active and not in a closing state. """
-        return self._writer is not None and not self._writer.is_closing()
+        writer_created = self._writer is not None
+        writer_active = writer_created and not self._writer.is_closing()
+        return writer_active
 
     @staticmethod
     def _format_command(command, param, pjclass: PJClass):

--- a/aiopjlink/projector.py
+++ b/aiopjlink/projector.py
@@ -213,7 +213,7 @@ class PJLink:
             raw = await asyncio.wait_for(self._reader.readuntil(b'\r'), self._timeout)
         except asyncio.IncompleteReadError as err:
             raise PJLinkConnectionClosed('projector closed the connection') from err
-        except TimeoutError as err:
+        except asyncio.exceptions.TimeoutError as err:
             raise PJLinkNoConnection('projector did not respond in time') from err
         return raw.decode(self._encoding)
 
@@ -256,6 +256,7 @@ class PJLink:
 
     @property
     def is_connected(self):
+        """ True if the connection is active and not in a closing state. """
         return self._writer is not None and not self._writer.is_closing()
 
     @staticmethod

--- a/aiopjlink/projector.py
+++ b/aiopjlink/projector.py
@@ -252,7 +252,7 @@ class PJLink:
         Returns:
             str: The response to the issued command.
         """
-        # Only one comman/reconnection at a time.
+        # Only one command/reconnection at a time.
         async with self._tx_lock:
 
             # Guard against lazy/unintended connections

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiopjlink"
-version = "1.0.5"
+version = "1.1.0"
 description = "Asyncio PJLink library (Class 1 and Class 2)"
 readme = "README.md"
 keywords = ["projector", "pjlink", "asyncio"]
@@ -31,6 +31,10 @@ build-backend = "pdm.pep517.api"
 
 [tool]
 [tool.pdm]
+[tool.pdm.build]
+includes = ["aiopjlink"]
+excludes = ["test", "test/*"]
+
 [tool.pdm.dev-dependencies]
 dev = [
     "flake8>=5.0.4",

--- a/test/test_projector.py
+++ b/test/test_projector.py
@@ -59,6 +59,9 @@ class PJLinkServerProtocol(asyncio.Protocol):
         # Buffer fore incoming messages until \r.
         self._recv_buffer = b''
 
+        # Simulates a non-responsive projector by ignoring client messages.
+        self.ignore_requests = False
+
     def _write(self, data):
         """ Send data to the client. """
         if self.debug:
@@ -84,6 +87,9 @@ class PJLinkServerProtocol(asyncio.Protocol):
         """ Called when the projector recieves data from the client. """
         if self.debug:
             print("PJLinkServerProtocol RECV:", data)
+
+        if self.ignore_requests:
+            return
 
         # Buffer up writes until we get a terminator.
         self._recv_buffer += data
@@ -564,6 +570,16 @@ class ProtocolTests(unittest.IsolatedAsyncioTestCase):
             expect_pjclass='1')
         self.assertEqual(command, 'INF2')
         self.assertEqual(param, '')
+
+    async def test_connection_drop_during_transmit(self):
+        """ Test that if the TCP connection dropped, PJLinkNoConnection is raised due to timeout. """
+        async with mock_tcp_pjlink() as server:
+            server.open_and_send(b'PJLINK 0\r')
+            # Use a very short timeout to simulate timeout behavior
+            async with aiopjlink.PJLink(address='127.0.0.1', password=None, timeout=0.1) as link:
+                server.ignore_requests = True
+                with self.assertRaises(aiopjlink.PJLinkNoConnection):
+                    await link.power.get()
 
 
 class PowerGroup(unittest.IsolatedAsyncioTestCase):

--- a/test/test_projector.py
+++ b/test/test_projector.py
@@ -3,6 +3,7 @@ import hashlib
 import unittest
 import platform
 import contextlib
+from unittest.mock import patch
 
 import aiopjlink.projector as aiopjlink
 
@@ -571,6 +572,11 @@ class ProtocolTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(command, 'INF2')
         self.assertEqual(param, '')
 
+
+class ConnectionTests(unittest.IsolatedAsyncioTestCase):
+    """ PJLink connection managment behaves as expected.
+    """
+
     async def test_connection_drop_during_transmit(self):
         """ Test that if the TCP connection dropped, PJLinkNoConnection is raised due to timeout. """
         async with mock_tcp_pjlink() as server:
@@ -580,6 +586,40 @@ class ProtocolTests(unittest.IsolatedAsyncioTestCase):
                 server.ignore_requests = True
                 with self.assertRaises(aiopjlink.PJLinkNoConnection):
                     await link.power.get()
+                    
+    async def test_transmit_auto_reconnect(self):
+        """ Verify transmit() triggers connect() if the client is not yet connected. """
+        async with mock_tcp_pjlink() as server:
+            server.open_and_send(b'PJLINK 0\r')
+            
+            # Initialize the client without 'async with' so it isn't connected yet
+            client = aiopjlink.PJLink(address='127.0.0.1')
+            
+            try:
+                # We wrap the real connect method to verify it gets called
+                with patch.object(aiopjlink.PJLink, 'connect', wraps=client.connect) as mock_connect:
+                    async with server.when(b'%1POWR ?\r', respond_with=b'%1POWR=0\r'):
+                        await client.transmit('POWR', '?', pjclass=aiopjlink.PJClass.ONE)
+                        
+                        # Verify auto-connection happened
+                        mock_connect.assert_called_once()
+            finally:
+                await client.disconnect()
+
+    async def test_transmit_persists_connection(self):
+        """ Verify transmit() does NOT call connect() if the connection is already active. """
+        async with mock_tcp_pjlink() as server:
+            server.open_and_send(b'PJLINK 0\r')
+            
+            # Use the context manager to establish the initial connection
+            async with aiopjlink.PJLink(address='127.0.0.1') as client:
+                # Wrap connect to see if it's called again
+                with patch.object(aiopjlink.PJLink, 'connect', wraps=client.connect) as mock_connect:
+                    async with server.when(b'%1POWR ?\r', respond_with=b'%1POWR=0\r'):
+                        await client.transmit('POWR', '?', pjclass=aiopjlink.PJClass.ONE)
+                        
+                        # Verify connect was NOT called again during transmit
+                        mock_connect.assert_not_called()
 
 
 class PowerGroup(unittest.IsolatedAsyncioTestCase):

--- a/test/test_projector.py
+++ b/test/test_projector.py
@@ -586,21 +586,21 @@ class ConnectionTests(unittest.IsolatedAsyncioTestCase):
                 server.ignore_requests = True
                 with self.assertRaises(aiopjlink.PJLinkNoConnection):
                     await link.power.get()
-                    
+
     async def test_transmit_auto_reconnect(self):
         """ Verify transmit() triggers connect() if the client is not yet connected. """
         async with mock_tcp_pjlink() as server:
             server.open_and_send(b'PJLINK 0\r')
-            
+
             # Initialize the client without 'async with' so it isn't connected yet
             client = aiopjlink.PJLink(address='127.0.0.1')
-            
+
             try:
                 # We wrap the real connect method to verify it gets called
                 with patch.object(aiopjlink.PJLink, 'connect', wraps=client.connect) as mock_connect:
                     async with server.when(b'%1POWR ?\r', respond_with=b'%1POWR=0\r'):
                         await client.transmit('POWR', '?', pjclass=aiopjlink.PJClass.ONE)
-                        
+
                         # Verify auto-connection happened
                         mock_connect.assert_called_once()
             finally:
@@ -610,14 +610,14 @@ class ConnectionTests(unittest.IsolatedAsyncioTestCase):
         """ Verify transmit() does NOT call connect() if the connection is already active. """
         async with mock_tcp_pjlink() as server:
             server.open_and_send(b'PJLINK 0\r')
-            
+
             # Use the context manager to establish the initial connection
             async with aiopjlink.PJLink(address='127.0.0.1') as client:
                 # Wrap connect to see if it's called again
                 with patch.object(aiopjlink.PJLink, 'connect', wraps=client.connect) as mock_connect:
                     async with server.when(b'%1POWR ?\r', respond_with=b'%1POWR=0\r'):
                         await client.transmit('POWR', '?', pjclass=aiopjlink.PJClass.ONE)
-                        
+
                         # Verify connect was NOT called again during transmit
                         mock_connect.assert_not_called()
 

--- a/test/test_projector.py
+++ b/test/test_projector.py
@@ -63,11 +63,14 @@ class PJLinkServerProtocol(asyncio.Protocol):
         # Simulates a non-responsive projector by ignoring client messages.
         self.ignore_requests = False
 
+        self.transport = None
+
     def _write(self, data):
         """ Send data to the client. """
         if self.debug:
             print("PJLinkServerProtocol SEND:", data)
-        self.transport.write(data)
+        if self.transport:
+            self.transport.write(data)
 
     def connection_made(self, transport):
         """ Called when a connection is first made to this projector. """
@@ -80,9 +83,9 @@ class PJLinkServerProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc):
         """ Called when the connection is lost or closed. """
+        self.transport = None
         if self.debug:
-            peer = self.transport.get_extra_info('peername')
-            print("PJLinkServerProtocol CONNECTION_LOST:", peer)
+            print("PJLinkServerProtocol CONNECTION_LOST")
 
     def data_received(self, data):
         """ Called when the projector recieves data from the client. """
@@ -111,7 +114,8 @@ class PJLinkServerProtocol(asyncio.Protocol):
                 expected.recv_buffer_contents = self._recv_buffer[:]
                 self.loop.call_soon_threadsafe(expected.set)
                 self._recv_buffer = b''
-                self.transport.close()
+                if self.transport:
+                    self.transport.close()
 
             # If the client sent an _expected_ message, flag it as correct,
             # save the buffer contents, and then reply with the expected
@@ -119,7 +123,8 @@ class PJLinkServerProtocol(asyncio.Protocol):
             else:
                 expected.recv_buffer_contents = self._recv_buffer[:]
                 self.loop.call_soon_threadsafe(expected.set)
-                self.transport.write(expected.respond_with)
+                if self.transport:
+                    self.transport.write(expected.respond_with)
                 self._recv_buffer = b''
 
     def open_and_send(self, message):
@@ -206,6 +211,10 @@ async def mock_tcp_pjlink(host='127.0.0.1', port=4352, password=None):
         yield protocol
     finally:
         server_task.cancel()
+        server.close()
+        await server.wait_closed()
+        if protocol.transport:
+            protocol.transport.close()
 
 
 @contextlib.asynccontextmanager
@@ -587,21 +596,40 @@ class ConnectionTests(unittest.IsolatedAsyncioTestCase):
                 with self.assertRaises(aiopjlink.PJLinkNoConnection):
                     await link.power.get()
 
-    async def test_transmit_auto_reconnect(self):
-        """ Verify transmit() triggers connect() if the client is not yet connected. """
+    async def test_transmit_without_explicit_connect_raises(self):
+        """ Verify transmit() blocks lazy connections if connect() was never explicitly called. """
+        # Initialize the client without 'async with' or 'await client.connect()'
+        client = aiopjlink.PJLink(address='127.0.0.1')
+
+        try:
+            with self.assertRaises(aiopjlink.PJLinkNoConnection) as err:
+                await client.transmit('POWR', '?', pjclass=aiopjlink.PJClass.ONE)
+            self.assertIn("explicitly connect", str(err.exception))
+        finally:
+            await client.disconnect()
+
+    async def test_transmit_auto_reconnect_after_drop(self):
+        """ Verify transmit() triggers connect() if the connection was previously active but dropped. """
         async with mock_tcp_pjlink() as server:
             server.open_and_send(b'PJLINK 0\r')
 
-            # Initialize the client without 'async with' so it isn't connected yet
             client = aiopjlink.PJLink(address='127.0.0.1')
 
             try:
-                # We wrap the real connect method to verify it gets called
+                # 1. Explicitly connect the first time
+                await client.connect()
+                self.assertTrue(client.is_connected)
+
+                # 2. Simulate a network drop by closing the transport/writer manually
+                client._writer.close()
+                self.assertFalse(client.is_connected)
+
+                # 3. Transmit a command, which should trigger a reconnect
                 with patch.object(aiopjlink.PJLink, 'connect', wraps=client.connect) as mock_connect:
                     async with server.when(b'%1POWR ?\r', respond_with=b'%1POWR=0\r'):
                         await client.transmit('POWR', '?', pjclass=aiopjlink.PJClass.ONE)
 
-                        # Verify auto-connection happened
+                        # Verify the recovery auto-connection happened
                         mock_connect.assert_called_once()
             finally:
                 await client.disconnect()


### PR DESCRIPTION
# Motivation
I want to use this library for PJLink integration inside of home assistant. But in order to do so, a few adaptions are necessary. So this is the first of three planned PRs to make the library usable for home assistant.

# Change
Add connect and disconnect function to enable the usage of PJLink without a context manager.
This is needed in order to store the instance of PJLink once and then use it in different places inside home assistant.

# Tests
All tests are still passing
Test coverage remains the same